### PR TITLE
Dockerfile 추가 및 DB 사전 모델 반영하도록 변경(flyway DB 모델 적용 삭제. 사전에 DB모델을 생성했기 때문)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM openjdk:15-slim
+LABEL maintainer="minseok.lee@sk.com"
+EXPOSE 8080
+COPY build/libs/order-0.0.1-SNAPSHOT.jar app.jar
+CMD ["java","-jar","/app.jar"]

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,6 +21,7 @@ spring:
     schemas: order
     url: jdbc:mysql://localhost:3306/order?serverTimezone=UTC&characterEncoding=UTF-8
     enabled: true
+    baselineOnMigrate: true
 
 #  h2:
 #    console:


### PR DESCRIPTION
1. Dockerfile 추가
2. DB 사전 모델 반영하도록 변경(flyway DB 모델 적용 삭제. 사전에 DB모델을 생성했기 때문)